### PR TITLE
Add new service limit checks added on 01/18/2019

### DIFF
--- a/deployment/limit-monitor-spoke.template
+++ b/deployment/limit-monitor-spoke.template
@@ -41,7 +41,7 @@ Mappings:
 
   EventsMap:
     Checks:
-      Services: '"AutoScaling","CloudFormation","EBS","EC2","ELB","IAM","Kinesis","RDS","SES","VPC"' #change if needed
+      Services: '"AutoScaling","CloudFormation","DynamoDB","EBS","EC2","ELB","IAM","Kinesis","RDS","Route53","SES","VPC"' #change if needed
 
 Resources:
   #

--- a/deployment/limit-monitor.template
+++ b/deployment/limit-monitor.template
@@ -70,7 +70,7 @@ Mappings:
 
   EventsMap:
     Checks:
-      Services: '"AutoScaling","CloudFormation","EBS","EC2","ELB","IAM","Kinesis","RDS","SES","VPC"' # change as needed
+      Services: '"AutoScaling","CloudFormation","DynamoDB","EBS","EC2","ELB","IAM","Kinesis","RDS","Route53","SES","VPC"' # change as needed
 
 Conditions:
   SingleAccnt: !Equals [!Ref AccountList , '']

--- a/source/services/tarefresh/lib/ta-refresh.js
+++ b/source/services/tarefresh/lib/ta-refresh.js
@@ -27,6 +27,10 @@ const serviceChecks = {
     'fW7HH0l7J9', 'aW7HH0l7J9'
   ],
   CloudFormation: ['gW7HH0l7J9'],
+  DynamoDB: [
+    '6gtQddfEw6',
+    'c5ftjdfkMr'
+  ],
   EBS: [
     'eI7KK0l7J9',
     'fH7LL0l7J9',
@@ -64,6 +68,13 @@ const serviceChecks = {
     'dYWBaXaaMM',
     'jEhCtdJKOY',
     'P1jhKWEmLa'
+  ],
+  Route53: [
+    'dx3xfcdfMr',
+    'ru4xfcdfMr',
+    'ty3xfcdfMr',
+    'dx3xfbjfMr',
+    'dx8afcdfMr'
   ],
   SES: ['hJ7NN0l7J9'],
   VPC: ['lN7RR0l7J9', 'kM7QQ0l7J9', 'jL7PP0l7J9']


### PR DESCRIPTION
*Issue #21*

*Description of changes:*
Added DynamoDB and Route53 checks to ta-refresh.js and new service categories to cloudformation templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
