### PR TITLE
Fix for `Error: Cannot find module 'uuid/v4'`

### DIFF
--- a/source/services/customhelper/lib/index.js
+++ b/source/services/customhelper/lib/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const uuidv4 = require('uuid/v4');
+const {"v4": uuidv4} = require('uuid');
 const https = require('https');
 const url = require('url');
 const moment = require('moment');


### PR DESCRIPTION
`uuid` npm module introduced breaking changes into a recent version. **At the time of this writing, this project's `package.json`'s don't have pinned versions, which is a problem in of itself.**

This PR resolves this error:
```
Error: Cannot find module 'uuid/v4'
Require stack:
- /Users/solsglasses/Projects/aws-limit-monitor/source/services/customhelper/lib/index.js
```

Fix is documented here:
https://stackoverflow.com/a/60614655/10802328